### PR TITLE
Fixed docker-compose and user model

### DIFF
--- a/alembic/versions/73ffa12c03c8_initial.py
+++ b/alembic/versions/73ffa12c03c8_initial.py
@@ -22,7 +22,7 @@ def upgrade() -> None:
                     sa.Column('username', sa.String(length=32), nullable=True),
                     sa.Column('first_name', sa.String(length=255), nullable=True),
                     sa.Column('last_name', sa.String(length=255), nullable=True),
-                    sa.Column('is_banned', sa.Boolean(), nullable=False),
+                    sa.Column('is_banned', sa.Boolean(), server_default='False', nullable=False),
                     sa.Column('deep_link', sa.String(length=225), nullable=True),
                     sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=True),
                     sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=True),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.3'
+version: '2.4'
 
 services:
   bot:

--- a/tgbot/models/user.py
+++ b/tgbot/models/user.py
@@ -8,5 +8,5 @@ class User(TimedBaseModel):
     username = db.Column(db.String(32), nullable=True)
     first_name = db.Column(db.String(255), nullable=True)
     last_name = db.Column(db.String(255), nullable=True)
-    is_banned = db.Column(db.Boolean, nullable=False, default=False)
+    is_banned = db.Column(db.Boolean, server_default="False", nullable=False)
     deep_link = db.Column(db.String(225), nullable=True)


### PR DESCRIPTION
- Changed `docker-compose.yml` version from `3.3` to `2.4` for **depends_on condition** support.
- Changed user model field value from `default` to `server_default` for **postgresql** support.